### PR TITLE
Only subscribe to INX topics if visualizer is used

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,14 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gorilla/websocket v1.5.0
 	github.com/iancoleman/orderedmap v0.2.0
-	github.com/iotaledger/hive.go/core v1.0.0-beta.4
+	github.com/iotaledger/hive.go/core v1.0.0-beta.4.0.20220905122421-b0510b4f7ed0
 	github.com/iotaledger/inx-app v1.0.0-beta.10
 	github.com/iotaledger/inx/go v1.0.0-beta.6
 	github.com/iotaledger/iota.go/v3 v3.0.0-beta.8
 	github.com/labstack/echo/v4 v4.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.0
+	go.uber.org/atomic v1.10.0
 	go.uber.org/dig v1.15.0
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
 	golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9
@@ -68,7 +69,6 @@ require (
 	github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.1 // indirect
-	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect
 	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b // indirect

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ github.com/iancoleman/orderedmap v0.2.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/iotaledger/hive.go/core v1.0.0-beta.4 h1:RgAyaSah+/HhAd9D0+gs2rLPSlGC6c+HxGt+4H1A4X8=
-github.com/iotaledger/hive.go/core v1.0.0-beta.4/go.mod h1:Uzx13jMaIOFEv/3po2XwKUbmNd3C5D0PixTIcG97/o4=
+github.com/iotaledger/hive.go/core v1.0.0-beta.4.0.20220905122421-b0510b4f7ed0 h1:2I0MkiCd/Zi/bMLBZmGtlbJWmGUNkIogncsHstNRW3M=
+github.com/iotaledger/hive.go/core v1.0.0-beta.4.0.20220905122421-b0510b4f7ed0/go.mod h1:Uzx13jMaIOFEv/3po2XwKUbmNd3C5D0PixTIcG97/o4=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-beta.3 h1:o7uLky3LQhNeMHZmNP7iaY67jdDUPRjKGL1GyvALQNM=
 github.com/iotaledger/hive.go/serializer/v2 v2.0.0-beta.3/go.mod h1:OMyV/ZEKiCzfqxXAmt1IBxl4Xmr6ipZFg6bjnzomtGc=
 github.com/iotaledger/inx-app v1.0.0-beta.10 h1:S1dkh+/pVgOlKjm1VFCS1HHHzsw81qy45k5xP4yRPVw=

--- a/pkg/dashboard/types.go
+++ b/pkg/dashboard/types.go
@@ -2,8 +2,8 @@ package dashboard
 
 // Msg represents a websocket message.
 type Msg struct {
-	Type byte        `json:"type"`
-	Data interface{} `json:"data"`
+	Type WebSocketMsgType `json:"type"`
+	Data interface{}      `json:"data"`
 }
 
 // PublicNodeStatus represents the public node status.


### PR DESCRIPTION
The dashboard creates a high CPU load if the visualizer streams are active even if no websocket client subscribed to it.

This PR changes the logic, so that INX streams are only subscribed if a client opened the "visualizer" tab in the browser.
With this change, the visualizer is not prefilled anymore, but this trade-off should be fine.